### PR TITLE
feat: Add plugin structure and improve documentation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "claude-router-marketplace",
+  "owner": {
+    "name": "Dan Monteiro",
+    "url": "https://github.com/0xrdan"
+  },
+  "plugins": [
+    {
+      "name": "claude-router",
+      "source": {
+        "source": "github",
+        "repo": "0xrdan/claude-router"
+      },
+      "description": "Intelligent model routing for Claude Code - routes queries to optimal Claude model (Haiku/Sonnet/Opus) based on complexity",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "claude-router",
+  "version": "1.0.0",
+  "description": "Intelligent model routing for Claude Code - routes queries to optimal Claude model (Haiku/Sonnet/Opus) based on complexity",
+  "author": {
+    "name": "Dan Monteiro"
+  },
+  "homepage": "https://github.com/0xrdan/claude-router",
+  "repository": "https://github.com/0xrdan/claude-router",
+  "license": "MIT",
+  "keywords": ["routing", "model-selection", "cost-optimization", "haiku", "sonnet", "opus"],
+  "hooks": "./hooks/hooks.json",
+  "agents": ["./agents/"],
+  "skills": ["./skills/"]
+}

--- a/README.md
+++ b/README.md
@@ -102,13 +102,23 @@ Haiku is a much smaller, faster model than Opus. When simple queries are routed 
 
 ## Installation
 
-### One-Command Install
+### Option 1: Claude Code Plugin (Recommended)
+
+```bash
+# Add the marketplace (one-time)
+/plugin marketplace add 0xrdan/claude-router
+
+# Install the plugin
+/plugin install claude-router
+```
+
+### Option 2: One-Command Install
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/0xrdan/claude-router/main/install.sh | bash
 ```
 
-### Manual Install
+### Option 3: Manual Install
 
 ```bash
 git clone https://github.com/0xrdan/claude-router.git
@@ -199,7 +209,7 @@ Use the `/route` skill for explicit routing:
 ## What Would Make People Use It
 
 1. **Zero-config start** - Works immediately with sensible defaults
-2. **Visible savings** - Show "You saved $X this session" (coming in Phase 4)
+2. **Visible savings** - Use `/router-stats` to see your cost savings
 3. **Trust through transparency** - Every routing decision is explained
 4. **Easy override** - `/route` skill for manual control when needed
 5. **Learns from feedback** - Future: adjust routing based on user overrides
@@ -210,13 +220,11 @@ Use the `/route` skill for explicit routing:
 - [x] **Phase 1:** Rule-based classification (~0ms, $0)
 - [x] **Phase 2:** Hybrid classification (rules + Haiku LLM fallback)
 - [x] **Phase 3:** Standalone repository
+- [x] **Phase 4:** Usage statistics and savings tracker
+  - Routing decisions logged to `~/.claude/router-stats.json`
+  - `/router-stats` skill shows savings and route distribution
 
 ### Coming Soon
-- [ ] **Phase 4:** Usage statistics and savings tracker
-  - Persist routing decisions to `~/.claude/router-stats.json`
-  - `/router-stats` skill to show savings
-  - "You saved $X this session" summaries
-
 - [ ] **Phase 5:** Context-aware routing
   - Factor in number of files open
   - Consider session history and error patterns

--- a/agents/deep-executor.md
+++ b/agents/deep-executor.md
@@ -1,0 +1,14 @@
+---
+name: deep-executor
+description: Complex analysis using Opus
+model: opus
+---
+
+Handle complex tasks: architecture, security, trade-off analysis.
+
+For non-trivial implementation tasks:
+1. Assess the scope and complexity
+2. If it requires exploring the codebase or multi-step planning, suggest: "This is a non-trivial task. I recommend entering plan mode to explore the codebase and design an approach. Should I proceed?"
+3. Wait for user confirmation before deep exploration
+
+Think deeply before responding. Provide thorough analysis.

--- a/agents/fast-executor.md
+++ b/agents/fast-executor.md
@@ -1,0 +1,8 @@
+---
+name: fast-executor
+description: Quick answers using Haiku
+model: haiku
+tools: Read, Grep, Glob
+---
+
+Be concise. Answer directly without over-explaining.

--- a/agents/standard-executor.md
+++ b/agents/standard-executor.md
@@ -1,0 +1,7 @@
+---
+name: standard-executor
+description: Standard coding tasks using Sonnet
+model: sonnet
+---
+
+Handle typical coding tasks: bug fixes, features, refactoring, tests. Be thorough but efficient.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -54,15 +54,15 @@ echo '{"prompt": "What is the syntax for a Python list?"}' | python3 .claude/hoo
    - Fix false positives/negatives
    - Add language-specific patterns
 
-2. **Usage Statistics (Phase 4)**
-   - Track routing decisions to `~/.claude/router-stats.json`
-   - Create `/router-stats` skill to display savings
-   - Show "You saved $X this session" summaries
-
-3. **Context-Aware Routing (Phase 5)**
+2. **Context-Aware Routing (Phase 5)**
    - Factor in number of files open
    - Consider session history
    - Adjust based on error patterns
+
+3. **Learning from Feedback (Phase 6)**
+   - Track user overrides
+   - Adjust future routing based on patterns
+   - Per-project routing profiles
 
 ### Good First Issues
 
@@ -80,26 +80,52 @@ echo '{"prompt": "What is the syntax for a Python list?"}' | python3 .claude/hoo
 
 ## Pull Request Process
 
-1. Create a feature branch:
+**Important:** All changes must go through pull requests. Never push directly to `main`.
+
+### Workflow
+
+1. **Sync with main:**
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+2. **Create a feature branch:**
    ```bash
    git checkout -b feature/your-feature-name
    ```
 
-2. Make your changes and commit:
+   Branch naming conventions:
+   - `feature/` - New features (e.g., `feature/phase-5-context-routing`)
+   - `fix/` - Bug fixes (e.g., `fix/classification-edge-case`)
+   - `docs/` - Documentation (e.g., `docs/improve-readme`)
+
+3. **Make your changes and commit:**
    ```bash
    git add .
-   git commit -m "Add: description of your change"
+   git commit -m "feat: description of your change"
    ```
 
-3. Push to your fork:
+4. **Push and create PR:**
    ```bash
-   git push origin feature/your-feature-name
+   git push -u origin feature/your-feature-name
+   gh pr create --title "Your PR title" --body "Description"
    ```
 
-4. Open a Pull Request with:
-   - Clear description of the change
-   - Any testing you've done
-   - Screenshots if applicable
+5. **After PR is merged:**
+   ```bash
+   git checkout main
+   git pull origin main
+   git branch -d feature/your-feature-name  # Delete local branch
+   ```
+
+### PR Requirements
+
+- Clear description of the change
+- Reference related issues (if any)
+- Testing you've done
+- Screenshots if applicable
+- Update relevant documentation (README, planning docs)
 
 ## Commit Message Format
 

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -569,23 +569,21 @@ claude-router/
 - Configuration options
 - Roadmap / contributing
 
-**Deliverables:**
-- [ ] Create GitHub repo (`claude-router` or `claude-code-router`)
-- [ ] One-command install script
-- [ ] Compelling README with demo
-- [ ] GitHub release with proper versioning
+**Deliverables (Complete):**
+- [x] Create GitHub repo: https://github.com/0xrdan/claude-router
+- [x] One-command install script (`install.sh`)
+- [x] Compelling README with three-fold savings explanation
+- [x] GitHub release v0.1.0
 - [ ] Share on relevant communities (Claude Discord, HN, Reddit)
 - [ ] Blog post / demo video for visibility
 
-### Phase 4: Stats Tracking (First Feature PR)
+### Phase 4: Stats Tracking ✅ COMPLETE
 
-Add after standalone repo is live - demonstrates active development:
-
-**Features:**
-- [ ] Persist routing decisions to `~/.claude/router-stats.json`
-- [ ] `/router-stats` skill to show savings
-- [ ] Session stats: "You saved $X this session"
-- [ ] Cumulative stats: "Total savings this month: $XX (73%)"
+**Features (Complete):**
+- [x] Persist routing decisions to `~/.claude/router-stats.json`
+- [x] `/router-stats` skill to show savings
+- [x] Per-day session tracking with route distribution
+- [x] Estimated savings calculation vs always-Opus baseline
 
 **Why This Matters:**
 - "You saved 73% on Claude Code" screenshots drive adoption
@@ -665,6 +663,18 @@ This is the correct architecture: **Custom Skill → Classifier → Appropriate 
 
 ## Changelog
 
+### January 3, 2026 - Phase 4 Complete
+- Implemented stats tracking to `~/.claude/router-stats.json`
+- Created `/router-stats` skill to display savings
+- Per-day session tracking with route distribution
+- Established PR workflow (feature branches, never push to main)
+
+### January 3, 2026 - Phase 3 Complete
+- Extracted to standalone repo: https://github.com/0xrdan/claude-router
+- Created portable install.sh with project/global install options
+- Wrote compelling README with three-fold savings explanation
+- Published v0.1.0 release
+
 ### January 3, 2026 - Phase 2 Complete
 - Implemented hybrid classification (rules + Haiku LLM fallback)
 - Added authoritative routing directive ("ACTION REQUIRED")
@@ -688,5 +698,5 @@ This is the correct architecture: **Custom Skill → Classifier → Appropriate 
 ---
 
 *Last updated: January 3, 2026*
-*Status: Phase 2 Complete - Hybrid classification working*
-*Next: Phase 3 (standalone repo) → Phase 4 (stats tracking as first feature PR)*
+*Status: Phase 4 Complete - Stats tracking live*
+*Next: Phase 5 (context-aware routing) → Phase 6 (learning from feedback)*

--- a/hooks/classify-prompt.py
+++ b/hooks/classify-prompt.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+Claude Router - UserPromptSubmit Hook
+Classifies prompts using hybrid approach:
+1. Rule-based patterns (instant, free)
+2. Haiku LLM fallback for low-confidence cases (~$0.001)
+
+Part of claude-router: https://github.com/0xrdan/claude-router
+"""
+import json
+import sys
+import os
+import re
+from pathlib import Path
+from datetime import datetime
+import fcntl
+
+# Confidence threshold for LLM fallback
+CONFIDENCE_THRESHOLD = 0.7
+
+# Stats file location
+STATS_FILE = Path.home() / ".claude" / "router-stats.json"
+
+# Cost estimates per 1M tokens (input/output)
+COST_PER_1M = {
+    "fast": {"input": 0.25, "output": 1.25},      # Haiku
+    "standard": {"input": 3.0, "output": 15.0},   # Sonnet
+    "deep": {"input": 15.0, "output": 75.0},      # Opus
+}
+
+# Average tokens per query (rough estimate)
+AVG_INPUT_TOKENS = 1000
+AVG_OUTPUT_TOKENS = 2000
+
+# Classification patterns
+PATTERNS = {
+    "fast": [
+        # Simple questions
+        r"^what (is|are|does) ",
+        r"^how (do|does|to) ",
+        r"^(show|list|get) .{0,30}$",
+        # Formatting
+        r"\b(format|lint|prettify|beautify)\b",
+        # Git simple ops
+        r"\bgit (status|log|diff|add|commit|push|pull)\b",
+        # JSON/YAML
+        r"\b(json|yaml|yml)\b.{0,20}$",
+        # Regex
+        r"\bregex\b",
+        # Syntax questions
+        r"\bsyntax (for|of)\b",
+        r"^(what|how).{0,50}\?$",
+    ],
+    "deep": [
+        # Architecture
+        r"\b(architect|architecture|design pattern|system design)\b",
+        r"\bscalable?\b",
+        # Security
+        r"\b(security|vulnerab|audit|penetration|exploit)\b",
+        # Multi-file
+        r"\b(across|multiple|all) (files?|components?|modules?)\b",
+        r"\brefactor.{0,20}(codebase|project|entire)\b",
+        # Trade-offs
+        r"\b(trade-?off|compare|pros? (and|&) cons?)\b",
+        r"\b(analyze|evaluate|assess).{0,30}(option|approach|strateg)\b",
+        # Complex
+        r"\b(complex|intricate|sophisticated)\b",
+        r"\boptimiz(e|ation).{0,20}(performance|speed|memory)\b",
+        # Planning
+        r"\b(multi-?phase|extraction|standalone repo|migration)\b",
+    ],
+}
+
+
+def get_api_key():
+    """Get API key from environment or common locations."""
+    # Try environment first
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if api_key:
+        return api_key
+
+    # Try common .env locations
+    search_paths = [
+        Path.cwd() / ".env",                           # Current directory
+        Path.cwd() / "server" / ".env",                # Server subdirectory
+        Path.home() / ".anthropic" / "api_key",        # Anthropic config
+        Path.home() / ".config" / "anthropic" / "key", # XDG config
+    ]
+
+    for env_path in search_paths:
+        try:
+            with open(env_path, "r") as f:
+                content = f.read()
+                # Handle both KEY=value and plain value formats
+                for line in content.split("\n"):
+                    if line.startswith("ANTHROPIC_API_KEY="):
+                        return line.strip().split("=", 1)[1].strip('"\'')
+                # If file is just the key (no assignment)
+                if content.strip().startswith("sk-ant-"):
+                    return content.strip()
+        except (FileNotFoundError, PermissionError):
+            continue
+
+    return None
+
+
+def calculate_cost(route: str, input_tokens: int = AVG_INPUT_TOKENS, output_tokens: int = AVG_OUTPUT_TOKENS) -> float:
+    """Calculate estimated cost for a route."""
+    costs = COST_PER_1M[route]
+    input_cost = (input_tokens / 1_000_000) * costs["input"]
+    output_cost = (output_tokens / 1_000_000) * costs["output"]
+    return input_cost + output_cost
+
+
+def log_routing_decision(route: str, confidence: float, method: str, signals: list):
+    """Log routing decision to stats file."""
+    try:
+        # Ensure directory exists
+        STATS_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+        # Load existing stats or create new
+        stats = {
+            "version": "1.0",
+            "total_queries": 0,
+            "routes": {"fast": 0, "standard": 0, "deep": 0},
+            "estimated_savings": 0.0,
+            "sessions": [],
+            "last_updated": None
+        }
+
+        if STATS_FILE.exists():
+            try:
+                with open(STATS_FILE, "r") as f:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+                    stats = json.load(f)
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            except (json.JSONDecodeError, IOError):
+                pass
+
+        # Update stats
+        stats["total_queries"] += 1
+        stats["routes"][route] += 1
+
+        # Calculate savings (compared to always using Opus)
+        actual_cost = calculate_cost(route)
+        opus_cost = calculate_cost("deep")
+        savings = opus_cost - actual_cost
+        stats["estimated_savings"] += savings
+
+        # Get or create today's session
+        today = datetime.now().strftime("%Y-%m-%d")
+        session = None
+        for s in stats.get("sessions", []):
+            if s["date"] == today:
+                session = s
+                break
+
+        if not session:
+            session = {
+                "date": today,
+                "queries": 0,
+                "routes": {"fast": 0, "standard": 0, "deep": 0},
+                "savings": 0.0
+            }
+            stats.setdefault("sessions", []).append(session)
+
+        session["queries"] += 1
+        session["routes"][route] += 1
+        session["savings"] += savings
+
+        # Keep only last 30 days of sessions
+        stats["sessions"] = sorted(stats["sessions"], key=lambda x: x["date"], reverse=True)[:30]
+
+        stats["last_updated"] = datetime.now().isoformat()
+
+        # Write stats atomically
+        with open(STATS_FILE, "w") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            json.dump(stats, f, indent=2)
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    except Exception:
+        # Don't fail the hook if stats logging fails
+        pass
+
+
+def classify_by_rules(prompt: str) -> dict:
+    """
+    Classify prompt using regex patterns.
+    Returns route, confidence, and signals.
+    """
+    prompt_lower = prompt.lower()
+    signals = []
+
+    # Check for deep patterns first (higher priority)
+    for pattern in PATTERNS["deep"]:
+        if re.search(pattern, prompt_lower):
+            match = re.search(pattern, prompt_lower)
+            signals.append(match.group(0) if match else pattern)
+            if len(signals) >= 2:
+                return {"route": "deep", "confidence": 0.9, "signals": signals[:3], "method": "rules"}
+
+    if signals:  # One deep signal
+        return {"route": "deep", "confidence": 0.7, "signals": signals, "method": "rules"}
+
+    # Check for fast patterns
+    fast_signals = []
+    for pattern in PATTERNS["fast"]:
+        if re.search(pattern, prompt_lower):
+            match = re.search(pattern, prompt_lower)
+            fast_signals.append(match.group(0) if match else pattern)
+            if len(fast_signals) >= 2:
+                return {"route": "fast", "confidence": 0.9, "signals": fast_signals[:3], "method": "rules"}
+
+    if fast_signals:  # One fast signal
+        return {"route": "fast", "confidence": 0.7, "signals": fast_signals, "method": "rules"}
+
+    # Default to standard with low confidence (triggers LLM fallback)
+    return {"route": "standard", "confidence": 0.5, "signals": ["no strong patterns"], "method": "rules"}
+
+
+def classify_by_llm(prompt: str, api_key: str) -> dict:
+    """
+    Classify prompt using Haiku LLM.
+    Used as fallback for low-confidence rule-based results.
+    """
+    try:
+        from anthropic import Anthropic
+    except ImportError:
+        return None
+
+    client = Anthropic(api_key=api_key)
+
+    classification_prompt = f"""Classify this coding query into exactly one route. Return ONLY valid JSON, no other text.
+
+Query: "{prompt}"
+
+Routes:
+- "fast": Simple factual questions, syntax lookups, formatting, git status, JSON/YAML manipulation
+- "standard": Bug fixes, feature implementation, code review, refactoring, test writing
+- "deep": Architecture decisions, system design, security audits, multi-file refactors, trade-off analysis, complex debugging
+
+Return JSON only:
+{{"route": "fast|standard|deep", "confidence": 0.0-1.0, "signals": ["signal1", "signal2"]}}"""
+
+    try:
+        message = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=100,
+            messages=[{"role": "user", "content": classification_prompt}]
+        )
+
+        response_text = message.content[0].text.strip()
+
+        # Handle potential markdown code blocks
+        if "```" in response_text:
+            response_text = response_text.split("```")[1]
+            if response_text.startswith("json"):
+                response_text = response_text[4:].strip()
+
+        result = json.loads(response_text)
+        result["method"] = "haiku-llm"
+        return result
+
+    except Exception as e:
+        # Log error but don't fail
+        print(f"LLM classification error: {e}", file=sys.stderr)
+        return None
+
+
+def classify_hybrid(prompt: str) -> dict:
+    """
+    Hybrid classification: rules first, LLM fallback for low confidence.
+    """
+    # Step 1: Rule-based classification (instant, free)
+    result = classify_by_rules(prompt)
+
+    # Step 2: If low confidence and API key available, use LLM
+    if result["confidence"] < CONFIDENCE_THRESHOLD:
+        api_key = get_api_key()
+        if api_key:
+            llm_result = classify_by_llm(prompt, api_key)
+            if llm_result:
+                return llm_result
+
+    return result
+
+
+def main():
+    """Main hook handler."""
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    prompt = input_data.get("prompt", "")
+
+    if not prompt or len(prompt) < 10:
+        sys.exit(0)
+
+    # Skip slash commands
+    if prompt.strip().startswith("/"):
+        sys.exit(0)
+
+    # Classify using hybrid approach
+    result = classify_hybrid(prompt)
+
+    route = result["route"]
+    confidence = result["confidence"]
+    signals = result["signals"]
+    method = result.get("method", "rules")
+
+    # Log routing decision to stats
+    log_routing_decision(route, confidence, method, signals)
+
+    # Map route to subagent and model
+    subagent_map = {"fast": "fast-executor", "standard": "standard-executor", "deep": "deep-executor"}
+    model_map = {"fast": "Haiku", "standard": "Sonnet", "deep": "Opus"}
+
+    subagent = subagent_map[route]
+    model = model_map[route]
+    signals_str = ", ".join(signals)
+
+    context = f"""[Claude Router] ROUTING DIRECTIVE
+Route: {route} | Model: {model} | Confidence: {confidence:.0%} | Method: {method}
+Signals: {signals_str}
+
+ACTION REQUIRED: Use the Task tool to spawn the "{subagent}" subagent with the user's query.
+Do not handle this query directly - delegate to the subagent for cost-optimized execution."""
+
+    print(context)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/classify-prompt.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/route/SKILL.md
+++ b/skills/route/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: route
+description: Route queries to optimal Claude model (Haiku/Sonnet/Opus) based on complexity. Use when user wants cost-optimized model selection.
+---
+
+# Query Router
+
+Routes queries to the most cost-effective Claude model while maintaining quality.
+
+## How It Works
+
+1. Analyze the query from $ARGUMENTS
+2. Classify complexity level
+3. Spawn the appropriate executor subagent
+4. Return the response with routing metadata
+
+## Classification Rules
+
+### fast (use fast-executor -> Haiku)
+Indicators:
+- Simple factual questions ("What is X?", "How do I Y?")
+- Code formatting, linting, prettifying
+- Git operations: status, log, diff, add, commit
+- JSON/YAML manipulation
+- Regex generation
+- File lookups and simple reads
+- Syntax questions
+
+### standard (use standard-executor -> Sonnet)
+Indicators:
+- Bug fixes ("fix", "error", "broken", "issue")
+- Feature implementation ("add", "implement", "create")
+- Code review
+- Refactoring ("refactor", "clean up", "improve")
+- Test writing
+- Documentation updates
+- Most typical coding tasks
+
+### deep (use deep-executor -> Opus)
+Indicators:
+- Architecture decisions ("architect", "design", "system")
+- Security audits ("security", "vulnerability", "audit")
+- Multi-file refactors ("across", "multiple files", "all components")
+- Trade-off analysis ("compare", "pros and cons", "trade-offs")
+- Performance optimization analysis
+- Complex debugging requiring deep reasoning
+- Extended thinking tasks
+
+## Instructions
+
+Given the query in $ARGUMENTS:
+
+1. **Classify** - Determine if it's fast, standard, or deep based on the rules above
+2. **Explain** - Briefly state your classification and the key signals
+3. **Route** - Use the Task tool to spawn the appropriate subagent:
+   - fast -> spawn "fast-executor" subagent
+   - standard -> spawn "standard-executor" subagent
+   - deep -> spawn "deep-executor" subagent
+4. **Return** - Prefix the response with the routing info
+
+## Example Usage
+
+User: `/route What's the syntax for a TypeScript interface?`
+
+Classification: **fast**
+Signals: Simple syntax question, factual lookup
+Routing to: Haiku (fast-executor)
+
+[Spawns fast-executor with the query]
+
+---
+
+User: `/route Fix the authentication bug in login.ts`
+
+Classification: **standard**
+Signals: Bug fix, single file, typical coding task
+Routing to: Sonnet (standard-executor)
+
+[Spawns standard-executor with the query]
+
+---
+
+User: `/route Design a scalable caching system for this API`
+
+Classification: **deep**
+Signals: Architecture decision, system design, trade-offs
+Routing to: Opus (deep-executor)
+
+[Spawns deep-executor with the query]

--- a/skills/router-stats/SKILL.md
+++ b/skills/router-stats/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: router-stats
+description: Display Claude Router usage statistics and cost savings
+---
+
+# Router Stats
+
+Display usage statistics and estimated cost savings from Claude Router.
+
+## Instructions
+
+Read the stats file at `~/.claude/router-stats.json` and present the data in a clear, formatted way.
+
+## Data Format
+
+The stats file contains:
+```json
+{
+  "version": "1.0",
+  "total_queries": 100,
+  "routes": {"fast": 30, "standard": 60, "deep": 10},
+  "estimated_savings": 12.50,
+  "sessions": [
+    {
+      "date": "2026-01-03",
+      "queries": 25,
+      "routes": {"fast": 8, "standard": 15, "deep": 2},
+      "savings": 3.20
+    }
+  ],
+  "last_updated": "2026-01-03T15:30:00"
+}
+```
+
+## Output Format
+
+Present the stats like this:
+
+```
+╔═══════════════════════════════════════════════════╗
+║           Claude Router Statistics                 ║
+╚═══════════════════════════════════════════════════╝
+
+📊 All Time
+───────────────────────────────────────────────────
+Total Queries Routed: 100
+
+Route Distribution:
+  Fast (Haiku):     30 (30%)  ████████░░░░░░░░░░░░
+  Standard (Sonnet): 60 (60%)  ████████████████░░░░
+  Deep (Opus):      10 (10%)  ████░░░░░░░░░░░░░░░░
+
+💰 Estimated Savings: $12.50
+   (compared to always using Opus)
+
+📅 Today (2026-01-03)
+───────────────────────────────────────────────────
+Queries: 25
+Savings: $3.20
+
+Route Distribution:
+  Fast: 8 | Standard: 15 | Deep: 2
+```
+
+## Steps
+
+1. Use the Read tool to read `~/.claude/router-stats.json`
+2. If the file doesn't exist, inform the user that no stats are available yet
+3. Calculate percentages for route distribution
+4. Format and display the statistics
+5. Include the savings comparison explanation
+
+## Notes
+
+- Savings are calculated assuming Opus would have been used for all queries
+- Cost estimates use: Haiku $0.25/$1.25, Sonnet $3/$15, Opus $15/$75 per 1M tokens
+- Average query estimated at 1K input + 2K output tokens


### PR DESCRIPTION
## Summary

- Add Claude Code plugin structure for `/plugin install` support
- Update documentation with PR workflow and Phase 4 completion
- Improve installation options

## Changes

### Plugin Structure
- `.claude-plugin/plugin.json` - Plugin manifest
- `.claude-plugin/marketplace.json` - Marketplace distribution config
- Root-level `hooks/`, `agents/`, `skills/` directories for plugin system
- `hooks/hooks.json` with `${CLAUDE_PLUGIN_ROOT}` for portable paths

### Documentation Updates
- **README.md**: Add plugin install as recommended option, mark Phase 4 complete
- **CONTRIBUTING.md**: Clear PR workflow (never push to main, branch naming conventions)
- **planning.md**: Mark Phase 3 and Phase 4 complete, update changelog

### Installation Options

Users can now install via:
1. **Plugin** (recommended): `/plugin install claude-router`
2. **One-command**: `curl -sSL .../install.sh | bash`
3. **Manual**: `git clone` + `./install.sh`

## Project Structure

```
claude-router/
├── .claude-plugin/           # Plugin system
│   ├── plugin.json
│   └── marketplace.json
├── .claude/                  # Standalone install
│   ├── hooks/, agents/, skills/
│   └── settings.json
├── hooks/                    # Plugin hooks
├── agents/                   # Plugin agents
├── skills/                   # Plugin skills
└── install.sh               # Standalone installer
```

## Test Plan

- [ ] Verify standalone install still works (`./install.sh`)
- [ ] Test plugin install (after merging to main)
- [ ] Verify all three routes work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)