### PR TITLE
fix: Correct plugin install commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,10 +7,7 @@
   "plugins": [
     {
       "name": "claude-router",
-      "source": {
-        "source": "github",
-        "repo": "0xrdan/claude-router"
-      },
+      "source": "./",
       "description": "Intelligent model routing for Claude Code - routes queries to optimal Claude model (Haiku/Sonnet/Opus) based on complexity",
       "version": "1.0.0"
     }

--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ Haiku is a much smaller, faster model than Opus. When simple queries are routed 
 /plugin marketplace add 0xrdan/claude-router
 
 # Install the plugin
-/plugin install claude-router
+/plugin install claude-router@claude-router-marketplace
+```
+
+To update when repo changes:
+```bash
+/plugin marketplace update claude-router-marketplace
 ```
 
 ### Option 2: One-Command Install


### PR DESCRIPTION
## Summary
Fix incorrect plugin installation commands in README.

## Changes
- Correct install command: `/plugin install claude-router@claude-router-marketplace`
- Add update command: `/plugin marketplace update claude-router-marketplace`
- Fix marketplace.json source to use local path (`./`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)