### PR TITLE
fix: Specify agent and skill files in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,6 +10,13 @@
   "license": "MIT",
   "keywords": ["routing", "model-selection", "cost-optimization", "haiku", "sonnet", "opus"],
   "hooks": "./hooks/hooks.json",
-  "agents": ["./agents/"],
-  "skills": ["./skills/"]
+  "agents": [
+    "./agents/fast-executor.md",
+    "./agents/standard-executor.md",
+    "./agents/deep-executor.md"
+  ],
+  "skills": [
+    "./skills/route/SKILL.md",
+    "./skills/router-stats/SKILL.md"
+  ]
 }


### PR DESCRIPTION
Plugin manifest requires explicit .md file paths, not directories