### PR TITLE
fix: Remove duplicate hooks declaration from plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,7 +9,6 @@
   "repository": "https://github.com/0xrdan/claude-router",
   "license": "MIT",
   "keywords": ["routing", "model-selection", "cost-optimization", "haiku", "sonnet", "opus"],
-  "hooks": "./hooks/hooks.json",
   "agents": [
     "./agents/fast-executor.md",
     "./agents/standard-executor.md",


### PR DESCRIPTION
## Summary
- Remove `hooks` field from plugin.json since Claude Code automatically loads `hooks/hooks.json`
- Fixes error: "Duplicate hooks file detected"

## Test plan
- [ ] Uninstall and reinstall plugin
- [ ] Verify no duplicate hooks error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)