### PR TITLE
chore: Release v1.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "claude-router",
       "source": "./",
       "description": "Intelligent model routing for Claude Code - routes queries to optimal Claude model (Haiku/Sonnet/Opus) based on complexity",
-      "version": "1.0.0"
+      "version": "1.0.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-router",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Intelligent model routing for Claude Code - routes queries to optimal Claude model (Haiku/Sonnet/Opus) based on complexity",
   "author": {
     "name": "Dan Monteiro"


### PR DESCRIPTION
## Summary
Bump version to v1.0.1

## Bug fixes in this release
- PR #8: Fix explicit agent/skill paths in plugin manifest
- PR #9: Fix duplicate hooks declaration error

🤖 Generated with [Claude Code](https://claude.com/claude-code)