### PR TITLE
fix: Use python3 to invoke hook script

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "claude-router",
       "source": "./",
       "description": "Intelligent model routing for Claude Code - routes queries to optimal Claude model (Haiku/Sonnet/Opus) based on complexity",
-      "version": "1.0.1"
+      "version": "1.0.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-router",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Intelligent model routing for Claude Code - routes queries to optimal Claude model (Haiku/Sonnet/Opus) based on complexity",
   "author": {
     "name": "Dan Monteiro"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/classify-prompt.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/classify-prompt.py",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
## Summary
- Invoke classify-prompt.py via `python3` instead of directly
- Fixes "Permission denied" error when plugin files don't have execute permissions

## Test plan
- [ ] Update plugin and verify hook runs without permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)