### PR TITLE
fix: Use plain text output for visible routing context

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "claude-router",
       "source": "./",
       "description": "Intelligent model routing for Claude Code - routes queries to optimal Claude model (Haiku/Sonnet/Opus) based on complexity",
-      "version": "1.0.4"
+      "version": "1.0.5"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-router",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Intelligent model routing for Claude Code - routes queries to optimal Claude model (Haiku/Sonnet/Opus) based on complexity",
   "author": {
     "name": "Dan Monteiro"

--- a/README.md
+++ b/README.md
@@ -104,14 +104,22 @@ Haiku is a much smaller, faster model than Opus. When simple queries are routed 
 
 ### Option 1: Claude Code Plugin (Recommended)
 
+Run these commands in any Claude Code session:
+
 ```bash
-# Add the marketplace (one-time)
+# Step 1: Add the marketplace (one-time, per project)
 /plugin marketplace add 0xrdan/claude-router
 
-# Install
+# Step 2: Install the plugin
 /plugin install claude-router@claude-router-marketplace
 
-# Update (or enable auto-update via /plugin → Marketplaces)
+# Step 3: Restart Claude Code session to activate
+```
+
+**Note:** The marketplace must be added in each project where you want to use Claude Router. Once added, updates are automatic.
+
+```bash
+# Update manually
 /plugin marketplace update claude-router-marketplace
 
 # Uninstall

--- a/hooks/classify-prompt.py
+++ b/hooks/classify-prompt.py
@@ -295,19 +295,15 @@ def main():
         try:
             input_data = json.load(sys.stdin)
         except json.JSONDecodeError:
-            # No valid input, exit silently with empty JSON
-            print("{}")
             sys.exit(0)
 
         prompt = input_data.get("prompt", "")
 
         if not prompt or len(prompt) < 10:
-            print("{}")
             sys.exit(0)
 
         # Skip slash commands
         if prompt.strip().startswith("/"):
-            print("{}")
             sys.exit(0)
 
         # Classify using hybrid approach
@@ -339,14 +335,12 @@ Signals: {signals_str}
 ACTION REQUIRED: Use the Task tool to spawn the "{subagent}" subagent with the user's query.
 Do not handle this query directly - delegate to the subagent for cost-optimized execution."""
 
-        # Output JSON for Claude Code hook
-        output = {"additionalContext": context}
-        print(json.dumps(output))
+        # Output plain text - appears in transcript AND goes to Claude
+        print(context)
         sys.exit(0)
 
     except Exception:
-        # Any error: output empty JSON to not break the hook
-        print("{}")
+        # Any error: exit silently
         sys.exit(0)
 
 


### PR DESCRIPTION
## Summary
- Switch from JSON `additionalContext` to plain text stdout
- Plain text appears in transcript AND goes to Claude (visible routing!)
- Updated README with clearer installation steps (marketplace is per-project)

## Test plan
- [ ] Update plugin, restart session
- [ ] Run a query and see routing directive in transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)