### PR TITLE
fix: Default to fast route when no patterns match

### DIFF
--- a/.claude/hooks/classify-prompt.py
+++ b/.claude/hooks/classify-prompt.py
@@ -215,8 +215,8 @@ def classify_by_rules(prompt: str) -> dict:
     if fast_signals:  # One fast signal
         return {"route": "fast", "confidence": 0.7, "signals": fast_signals, "method": "rules"}
 
-    # Default to standard with low confidence (triggers LLM fallback)
-    return {"route": "standard", "confidence": 0.5, "signals": ["no strong patterns"], "method": "rules"}
+    # Default to fast with low confidence - cheaper when uncertain
+    return {"route": "fast", "confidence": 0.5, "signals": ["no strong patterns"], "method": "rules"}
 
 
 def classify_by_llm(prompt: str, api_key: str) -> dict:

--- a/hooks/classify-prompt.py
+++ b/hooks/classify-prompt.py
@@ -215,8 +215,8 @@ def classify_by_rules(prompt: str) -> dict:
     if fast_signals:  # One fast signal
         return {"route": "fast", "confidence": 0.7, "signals": fast_signals, "method": "rules"}
 
-    # Default to standard with low confidence (triggers LLM fallback)
-    return {"route": "standard", "confidence": 0.5, "signals": ["no strong patterns"], "method": "rules"}
+    # Default to fast with low confidence - cheaper when uncertain
+    return {"route": "fast", "confidence": 0.5, "signals": ["no strong patterns"], "method": "rules"}
 
 
 def classify_by_llm(prompt: str, api_key: str) -> dict:


### PR DESCRIPTION
## Summary
- When the router is uncertain (no patterns match), default to "fast" (Haiku) instead of "standard" (Sonnet)
- More cost-effective for simple greetings, test messages, and other unrecognized queries
- LLM fallback still triggers at <70% confidence for better classification when API key is available

## Test plan
- [ ] Send a simple greeting like "Hi" and verify it routes to fast
- [ ] Send a coding query and verify it still routes appropriately
- [ ] Verify deep patterns still route to deep

🤖 Generated with [Claude Code](https://claude.com/claude-code)