### PR TITLE
fix: Sync marketplace hook with working version

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,17 +230,20 @@ Models: `haiku`/`fast`, `sonnet`/`standard`, `opus`/`deep`
 
 ```
 claude-router/
-├── hooks/
-│   └── classify-prompt.py     # Hybrid classifier (auto-routing)
-├── commands/
-│   ├── route.md               # /route command
-│   └── router-stats.md        # /router-stats command
-├── agents/
-│   ├── fast-executor.md       # Haiku agent
-│   ├── standard-executor.md   # Sonnet agent
-│   └── deep-executor.md       # Opus agent
-└── skills/
-    └── route/                 # Auto-invoked routing skill
+├── .claude/                       # Manual install files
+│   ├── hooks/
+│   │   └── classify-prompt.py     # Hybrid classifier (auto-routing)
+│   ├── agents/
+│   │   ├── fast-executor/         # Haiku agent
+│   │   ├── standard-executor/     # Sonnet agent
+│   │   └── deep-executor/         # Opus agent
+│   └── skills/
+│       └── route/                 # Manual routing skill
+├── hooks/                         # Marketplace plugin files
+│   ├── classify-prompt.py         # Same classifier (synced)
+│   └── hooks.json                 # Plugin hook config
+├── install.sh                     # Installation script
+└── uninstall.sh                   # Uninstallation script
 ```
 
 ## Why Anthropic Should Care


### PR DESCRIPTION
## Summary
- Synced `hooks/classify-prompt.py` (marketplace) with `.claude/hooks/classify-prompt.py` (manual install)
- Removed stderr suppression and JSON wrapper that could cause hook errors
- Updated README to document both installation paths

## Problem
The two hook files were out of sync:
- Marketplace version had stderr suppression and JSON `hookSpecificOutput` wrapper
- Manual install version used simple `print(context)` 

This caused potential "hook error" messages for marketplace plugin users.

## Test plan
- [ ] Test marketplace plugin installation
- [ ] Test manual installation
- [ ] Verify routing context appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)